### PR TITLE
Make use of length parameter in number()

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function string(length) {
 function number(length) {
   var text = "";
   var possible = "0123456789";
-  for (var i=0; i < 2; i++)
+  for (var i=0; i < length; i++)
     text += possible.charAt(Math.floor(Math.random() * possible.length));
   return text;
 }


### PR DESCRIPTION
The length parameter was added to number(), but it isn't actually used
(it still uses 2)
